### PR TITLE
Add baseline file option

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    tests,
+    build,
+    dist
+
+max-line-length = 102
+addons = file,open,basestring,xrange,unicode,long,cmp

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,15 @@
+# https://github.com/cmheisel/pylintrcs/blob/master/pylintrc
+[MASTER]
+ignore=tests
+
+profile=no
+
+jobs=1
+
+suggestion-mode=yes
+
+[REPORTS]
+output-format=colorized
+
+[FORMAT]
+max-line-length=102

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ The `with` portion of the workflow **must** be configured before the action will
 One of the following deployment options must be configured.
 
 | Key                | Value Information                                                                                                                                                                                                                                                                                                                                     | Type   | Required | Default |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------- | -------- |
-| `PROJECT_PATH` | To provide you python location at which this security check needed to be done.                                                                                                 | `with` | **No**  | "." |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------- | -------- |
+| `PROJECT_PATH` | To provide you python location at which this security check needed to be done.                                                                                             | `with` | **No**  | "." |
 | `IGNORE_FAILURE` | This is to ignore the security failures and pass the check.                                                                                                 | `with` | **No**  | false |
+| `BASELINE_FILE` | An optional baseline file. By default, no file is used.                                                                                                 | `with` | **No**  | "" |
 | `CONFIG_FILE` | An optional config file. By default, no file is used.                                                                                                 | `with` | **No**  | "" |
 
 
@@ -98,7 +99,7 @@ One of the following deployment options must be configured.
 
 #### Bandit report (security checks report) 👮‍♂️
 
-The following is an bandit report for a django project. 
+The following is a bandit report for a django project. 
 [learn more about bandit](https://pypi.org/project/bandit/).
 
 ```txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Security check - Bandit](https://github.com/ioggstream/bandit-report-artifacts/workflows/Bandit%20checks/badge.svg)
-  
+
 This <a href="https://github.com/features/actions">GitHub Action</a> runs
 bandit checks on your code and annotates the interested lines with the
 reported issues.
@@ -93,6 +93,9 @@ One of the following deployment options must be configured.
 | `BASELINE_FILE` | An optional baseline file. By default, no file is used.                                                                                                 | `with` | **No**  | "" |
 | `CONFIG_FILE` | An optional config file. By default, no file is used.                                                                                                 | `with` | **No**  | "" |
 
+
+Note: the baseline and config file options are mutually exclusive, ie, choose
+one or the other option (not both).
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 #
-# Forked from  Joel-hanson/bandit-report-artifacts
+# Forked from  ioggstream/bandit-report-artifacts
 #
 name: "python-bandit with code annotations"
 description: "Github action to find common security issues in Python code and get its report as a artifact."
@@ -15,6 +15,11 @@ inputs:
     description: "This is to ignore the security failures and pass the check."
     required: false
     default: false
+
+  baseline_file:
+    description: "The json baseline data file to use"
+    required: false
+    default: ""
 
   config_file:
     description: "The yaml config file to use"
@@ -34,4 +39,4 @@ runs:
 
 branding:
   icon: "shield"
-  color: "gray-dark"
+  color: "red-dark"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,12 +15,12 @@ fi
 bandit ${BANDIT_CONFIG} -r "${INPUT_PROJECT_PATH}" -o "${GITHUB_WORKSPACE}/output/security_report.txt" -f 'txt'
 BANDIT_STATUS="$?"
 
-GITHUB_TOKEN=$INPUT_REPO_TOKEN python /main.py -r $INPUT_PROJECT_PATH
-
 if [ $BANDIT_STATUS -eq 0 ]; then
     echo "🔥🔥🔥🔥Security check passed🔥🔥🔥🔥"
     exit 0
 fi
+
+GITHUB_TOKEN=$INPUT_REPO_TOKEN python /main.py -r $INPUT_PROJECT_PATH
 
 echo "🔥🔥🔥🔥Security check failed🔥🔥🔥🔥"
 cat $GITHUB_WORKSPACE/output/security_report.txt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,9 @@ touch $GITHUB_WORKSPACE/output/security_report.txt
 if [ -f "${INPUT_CONFIG_FILE}" ]; then
     echo "Using config file: ${INPUT_CONFIG_FILE}"
     BANDIT_CONFIG="-c ${INPUT_CONFIG_FILE}"
+elif [ -f "${INPUT_BASELINE_FILE}" ]; then
+    echo "Using baseline file: ${INPUT_BASELINE_FILE}"
+    BANDIT_CONFIG="-b ${INPUT_BASELINE_FILE}"
 fi
 
 bandit ${BANDIT_CONFIG} -r "${INPUT_PROJECT_PATH}" -o "${GITHUB_WORKSPACE}/output/security_report.txt" -f 'txt'

--- a/main.py
+++ b/main.py
@@ -1,12 +1,14 @@
-from collections import namedtuple
-from pathlib import Path
-import requests
 import json
+
+from pathlib import Path
+
 from subprocess import (  # nosec - module is used cleaning environment variables and with shell=False
     run,
 )
 from datetime import datetime, timezone
 from os import environ
+
+import requests
 
 
 def gh(url, method="GET", data=None, headers=None, token=None):
@@ -69,11 +71,11 @@ def bandit_error(error):
     message = error["reason"]
     try:
         parse(Path(error["filename"]).read_text())
-    except SyntaxError as e:
-        title, _ = e.args
-        end_line = start_line = e.lineno
-        message = e.msg
-    except Exception as e:  # nosec - I really want to ignore further exceptions here.
+    except SyntaxError as exc:
+        title, _ = exc.args  # noqa - need to handle different size tuples
+        end_line = start_line = exc.lineno
+        message = exc.msg
+    except Exception:  # nosec - I really want to ignore further exceptions here.
         # Use default error values
         pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,62 @@
+[tox]
+envlist = tests
+skip_missing_interpreters = true
+isolated_build = true
+skipsdist = true
+
+[testenv]
+basepython = python3.8
+install_command = pip install {opts} {packages}
+
+[testenv:tests]
+passenv = CI PYTHON PYTHONIOENCODING
+
+setenv = PYTHONPATH = {toxinidir}
+
+deps =
+    pip>=20.0.1
+    wheel
+    pytest
+    pylint
+    -r requirements.txt
+
+commands =
+    pytest -v . []
+
+[testenv:lint]
+envdir = {toxworkdir}/tests
+
+passenv =
+    {[testenv:tests]passenv}
+
+deps =
+    {[testenv:tests]deps}
+
+commands =
+    pylint --fail-under=7 main.py
+
+[testenv:sec]
+envdir = {toxworkdir}/tests       
+
+passenv =
+    {[testenv:tests]passenv}
+
+deps =
+    pip>=20.0.1
+    bandit
+
+commands =
+    bandit main.py
+
+[testenv:style]
+envdir = {toxworkdir}/tests
+
+passenv =
+    {[testenv:tests]passenv}
+
+deps =
+    pip>=20.0.1
+    flake8
+
+commands =
+    flake8 main.py tests/test_main.py


### PR DESCRIPTION
Based on upstream docs, I found this option to be the solution I was looking for (as opposed to config file or # no-sec options).  I wanted to run the tests locally, so I also added a tox.ini and some tool configs, then applied some cleanup so at least flake8 is happy.  Testing in my (target) workflow looks good, now it's your turn to take a look ;)

I can always rebase if you'd rather have only the baseline-or-config-file changes.

Thanks!