### PR TITLE
Change title of results if errors or annotations

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,6 +103,7 @@ def bandit_run_check(results, github_sha=None, dummy=False):
 
     if errors or annotations:
         conclusion = "failure"
+        title = f"Bandit: {len(errors)} errors and {len(annotations)} annotations found"
     if dummy:
         conclusion = "neutral"
         name = "Bandit dummy run"


### PR DESCRIPTION
The title `Bandit: no issues found` was always displayed, even if there were errors or annotations.
See e.g. [this workflow run for Darker](https://github.com/akaihola/darker/pull/313/checks?check_run_id=5665351352).

This patch will display this instead if at least one error or annotation was found (with error/annotation counts for XX and YY):

    Bandit: XX errors and YY annotations found