### PR TITLE
Pass `-c ${INPUT_CONFIG_FILE}` to `main.py`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 bandit ${BANDIT_CONFIG} -r "${INPUT_PROJECT_PATH}" -o "${GITHUB_WORKSPACE}/output/security_report.txt" -f 'txt'
 BANDIT_STATUS="$?"
 
-GITHUB_TOKEN=$INPUT_REPO_TOKEN python /main.py -r $INPUT_PROJECT_PATH
+GITHUB_TOKEN=$INPUT_REPO_TOKEN python /main.py ${BANDIT_CONFIG} -r $INPUT_PROJECT_PATH
 
 if [ $BANDIT_STATUS -eq 0 ]; then
     echo "🔥🔥🔥🔥Security check passed🔥🔥🔥🔥"


### PR DESCRIPTION
If the `config_file:` option was defined in the workflow, `entrypoint.sh` did call `bandit` once with `-c ${INPUT_CONFIG_FILE}`, but didn't pass the option on to `main.py` for the second `bandit` call.

See akaihola/darker#313 for the symptom this used to cause.

This patch makes sure all `bandit` calls use the same `-c` option value.