### PR TITLE
Upgrade base Docker image to use Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 
-RUN apt-get update
+RUN apt-get update && apt-get upgrade -y
 
 ADD entrypoint.sh /
 ADD requirements.txt /


### PR DESCRIPTION
- Upgrade base Docker image to use Debian Bookworm; Buster is EOL.
- Add `apt-get upgrade` after `apt-get update` to actually upgrade the packages.